### PR TITLE
UI Tweaks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xmx3G
 #Forge
 mc_version=1.12.2
-forge_version=14.23.5.2846
+forge_version=14.23.5.2847
 mc_mappings=snapshot_20171003
 #Dependencies
 jei_version=4.11.0.206

--- a/src/main/java/arekkuusu/enderskills/client/ClientConfig.java
+++ b/src/main/java/arekkuusu/enderskills/client/ClientConfig.java
@@ -19,6 +19,8 @@ public final class ClientConfig {
             public boolean renderUnowned = false;
             public boolean renderOverlay = true;
             public boolean renderControls = true;
+            public boolean renderTitle = true;
+            public boolean renderDenominator = true;
             public double scale = 1D;
             public int posX = 5;
             public int posY = 50;
@@ -29,6 +31,7 @@ public final class ClientConfig {
 
         public static class Endurance {
             public boolean renderOverlay = true;
+            public boolean renderTitle = true;
             public double scale = 1D;
             public int size = 182;
             public int posX = 5;

--- a/src/main/java/arekkuusu/enderskills/client/proxy/Events.java
+++ b/src/main/java/arekkuusu/enderskills/client/proxy/Events.java
@@ -162,7 +162,8 @@ public class Events {
                     drawTexturedRectangle(x, (display.size() * step) + y + 2, 0, 27, size * 2, 5, 32, 5, 64);
                 }
                 //Skill group title
-                renderText(TextHelper.translate("skill_group.title"), x, y - 2, 0.5D, 0xFFFFFF);
+                if (ClientConfig.RENDER_CONFIG.endurance.renderTitle) //Config toggle for skill_group.title
+                { renderText(TextHelper.translate("skill_group.title"), x, y - 2, 0.5D, 0xFFFFFF); }
                 GlStateManager.scale(mSize, mSize, mSize);
                 GlStateManager.popMatrix();
                 x = posX + 4;
@@ -206,7 +207,10 @@ public class Events {
                         renderText(control, x, y + 14, 0.3D, hasCool ? 0x8C605D : 8453920);
                     }
                     if (hasCool && info != null) {
-                        renderText(TextHelper.translate("cooldown.timer", cool), x + 1, y + 1, 0.5D, 0xFFFFFF);
+                        if (ClientConfig.RENDER_CONFIG.skillGroup.renderDenominator)
+                        { renderText(TextHelper.translate("cooldown.timer", cool), x + 1, y + 1, 0.5D, 0xFFFFFF); }
+                        else
+                        { renderText(TextHelper.translate("cooldown.timer.noDenominator", cool), x + 1, y + 1, 0.5D, 0xFFFFFF); }
                     }
                     GlStateManager.scale(mSize, mSize, mSize);
                     GlStateManager.popMatrix();
@@ -331,11 +335,13 @@ public class Events {
             }
             //Endurance title
             if (horizontal) {
-                renderText(TextHelper.translate("endurance.title", (int) endurance, (int) enduranceMax), x - 4, y - 5, 0.5D, 0xFFFFFF);
+                if (ClientConfig.RENDER_CONFIG.endurance.renderTitle) //config toggle for endurance.title
+                { renderText(TextHelper.translate("endurance.title", (int) endurance, (int) enduranceMax), x - 4, y - 5, 0.5D, 0xFFFFFF); }
                 String text = TextHelper.translate("endurance.amount", (int) endurance, (int) enduranceMax);
                 renderText(text, x - mc.fontRenderer.getStringWidth(text) / 2 + width / 2, y, 0.8D, 0xFFFFFF);
             } else {
-                renderText(TextHelper.translate("endurance.title", (int) endurance, (int) enduranceMax), x - 4, y - 5, 0.5D, 0xFFFFFF);
+                if (ClientConfig.RENDER_CONFIG.endurance.renderTitle) //config toggle for endurance.title
+                { renderText(TextHelper.translate("endurance.title", (int) endurance, (int) enduranceMax), x - 4, y - 5, 0.5D, 0xFFFFFF); }
                 String text = TextHelper.translate("endurance.amount", (int) endurance, (int) enduranceMax);
                 renderText(text, x, y - mc.fontRenderer.FONT_HEIGHT / 2 + width / 2, 0.8D, 0xFFFFFF);
             }

--- a/src/main/resources/assets/enderskills/lang/en_us.lang
+++ b/src/main/resources/assets/enderskills/lang/en_us.lang
@@ -140,6 +140,7 @@ ui.enderskills.gui.advancement.requires_xp=\n- %s XP.
 ui.enderskills.gui.advancement.undone_warning=\n\n§4This action cannot be undone.§r
 
 ui.enderskills.cooldown.timer=%1$ss
+ui.enderskills.cooldown.timer.noDenominator=%1$s
 ui.enderskills.endurance.title=Endurance
 ui.enderskills.endurance.amount=%s
 ui.enderskills.skill_group.title=Abilities

--- a/src/main/resources/assets/enderskills/lang/ru_ru.lang
+++ b/src/main/resources/assets/enderskills/lang/ru_ru.lang
@@ -132,6 +132,7 @@ ui.enderskills.gui.advancement.requires_xp=\n- %s XP.
 ui.enderskills.gui.advancement.undone_warning=\n\n§4Это действие нельзя отменить.§r
 
 ui.enderskills.cooldown.timer=%1$ss
+ui.enderskills.cooldown.timer.noDenominator=%1$s
 ui.enderskills.endurance.title=Выносливость
 ui.enderskills.endurance.amount=%s
 ui.enderskills.skill_group.title=Навыки


### PR DESCRIPTION
**Expanded config**
Endurance: renderTitle
Skillgroup: renderTitle/renderDenominator
Updated from Forge 2847 to 2846 as its newer and doesn't seem to break compatibility at all

**To-do**
- [ ] Allow the skill-group timer to be centered
- [ ] Allow removing the modifier key so its not visible within the skills
- [ ] Make it so skills relying on the modifier key gets put in the lowest numbered slots
- [ ] Add integration with classic bars
- [ ] Add font resizing to solve poor scaling with certain UI scales
- [ ] whatever is suggested to me that I think sounds worthwhile!

If there is anything I need to change for the pull request to be accepted, then feel free to tell.